### PR TITLE
#37 add /credit_score/kyc endpoint

### DIFF
--- a/routers/kyc.py
+++ b/routers/kyc.py
@@ -1,16 +1,19 @@
 from testing.performance import *
 from config.helper import *
 from support.helper import *
-from support.risk import *
-from support.feedback import *
-from support.score import *
 from market.coinmarketcap import *
 from validator.plaid import *
 from validator.coinbase import *
 from validator.covalent import *
+from support.metrics_plaid import *
+from support.metrics_coinbase import *
+from support.metrics_covalent import *
 from schemas import *
 from fastapi import APIRouter, Request, Response, HTTPException, status
 from icecream import ic
+from dotenv import load_dotenv
+from os import getenv
+load_dotenv()
 
 
 router = APIRouter(
@@ -26,18 +29,122 @@ async def credit_score_kyc(request: Request, response: Response, item: KYC_Item)
     Calculates credit score based on KYC data from one of the validators.
 
     Input:
+    - **chosen_validator [string]**: chosen validator
     - **plaid_access_token [string | Optional]**: plaid access token
     - **plaid_client_id [string | Optional]**: plaid client ID
     - **plaid_client_secret [string | Optional]**: plaid client secret
     - **coinbase_access_token [string | Optional]**: coinbase access token
     - **coinbase_refresh_token [string | Optional]**: coinbase refresh token
+    - **coinmarketcap_key [string | Optional]**: coinmarketcap key
     - **eth_address [string | Optional]**: eth address
     - **covalent_key [string | Optional]**: covalentkey
-    - **coinmarketcap_key [string]**: coinmarketcap key
-    - **loan_request [integer]**: loan request amount
 
     Output:
-    - **[object]**: kyc credit score
+    - **[object]**: kyc verification
     '''
 
-    return {'status': 'under construction'}
+    try:
+        # configs
+        configs = read_config_file(0)
+        if isinstance(configs, str):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail='Unable to read config file.')
+
+        thresholds = configs['minimum_requirements'][item.chosen_validator]['thresholds']
+        ic(thresholds)
+
+        # kyc models
+        ic(item.chosen_validator)
+        if item.chosen_validator == 'plaid':
+            # plaid client connection
+            client = plaid_client(
+                getenv('ENV'), item.plaid_client_id, item.plaid_client_secret)
+            ic(client)
+
+            # data fetching
+            transactions = plaid_transactions(
+                item.plaid_access_token, client, thresholds['transactions_period'])
+            if isinstance(transactions, str):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f'Unable to fetch transactions data: {transactions}')
+
+            # verify kyc
+            kyc_verified = plaid_kyc(transactions)
+
+        elif item.chosen_validator == 'coinbase':
+            # coinmarketcap
+            top_marketcap = coinmarketcap_currencies(
+                item.coinmarketcap_key, thresholds['coinmarketcap_currencies'])
+            if isinstance(top_marketcap, str):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f'Unable to fetch coinmarketcap data: {top_marketcap}')
+
+            # coinbase client connection
+            client = coinbase_client(
+                item.coinbase_access_token, item.coinbase_refresh_token)
+            ic(client)
+
+            # coinbase supported currencies
+            currencies = coinbase_currencies(client)
+            if 'error' in currencies:
+                error = currencies['error']['message']
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f'Unable to fetch coinbase data: {error}')
+
+            # add top coinmarketcap currencies and coinbase currencies
+            top_currencies = aggregate_currencies(
+                top_marketcap, currencies, thresholds['odd_fiats'])
+
+            # data fetching
+            accounts, transactions = coinbase_accounts_and_transactions(
+                client, top_currencies, thresholds['transaction_types'])
+            if isinstance(accounts, str):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f'Unable to fetch accounts data: {accounts}')
+            if isinstance(transactions, str):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f'Unable to fetch transactions data: {transactions}')
+
+            # verify kyc
+            kyc_verified = coinbase_kyc(accounts, transactions)
+
+        elif item.chosen_validator == 'covalent':
+            # data fetching
+            balances = covalent_get_balances_or_portfolio(
+                '1', item.eth_address, 'balances_v2', item.covalent_key)
+            if isinstance(balances, str):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f'Unable to fetch balances data: {balances}')
+
+            transactions = covalent_get_transactions(
+                '1', item.eth_address, item.covalent_key, False, 500, 0)
+            if isinstance(transactions, str):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f'Unable to fetch transactions data: {transactions}')
+
+            # verify kyc
+            kyc_verified = covalent_kyc(balances, transactions)
+
+        # return success
+        status = 'success'
+        ic(kyc_verified)
+
+    except Exception as e:
+        status = 'error'
+        kyc_verified = False
+
+    finally:
+        return {
+            'endpoint': '/credit_score/kyc',
+            'status': status,
+            'validator': item.chosen_validator,
+            'kyc_verified': kyc_verified
+        }

--- a/schemas.py
+++ b/schemas.py
@@ -25,12 +25,12 @@ class Covalent_Item(BaseModel):
 
 
 class KYC_Item(BaseModel):
+    chosen_validator: str
     plaid_access_token: Optional[str]
     plaid_client_id: Optional[str]
     plaid_client_secret: Optional[str]
     coinbase_access_token: Optional[str]
     coinbase_refresh_token: Optional[str]
+    coinmarketcap_key: Optional[str]
     eth_address: Optional[str]
     covalent_key: Optional[str]
-    coinmarketcap_key: str
-    loan_request: int

--- a/support/metrics_coinbase.py
+++ b/support/metrics_coinbase.py
@@ -71,7 +71,7 @@ def net_flow(txn, timeframe, feedback):
 
 
 # @measure_time_and_memory
-def coinbase_kyc(acc, txn, feedback):
+def coinbase_kyc(acc, txn):
     '''
     Description:
         returns 1 if the oracle believes this is a legitimate user
@@ -80,28 +80,21 @@ def coinbase_kyc(acc, txn, feedback):
     Parameters:
         acc (list): non-zero balance Coinbase accounts owned by the user in currencies of trusted reputation
         txn (list): transactions history of above-listed accounts
-        feedback (dict): score feedback
 
     Returns:
-        score (int): binary kyc verification 1|0
-        feedback (dict): score feedback
+        (boolean): binary kyc verification 1|0
     '''
 
     try:
         # Pass KYC check iff the Coinbase account has trusted data
         if acc and txn:
-            score = 1
-            feedback['kyc']['pass_check'] = True
+            return True
         else:
-            score = 0
-            feedback['kyc']['pass_check'] = False
+            return False
 
     except Exception as e:
-        score = 0
-        feedback['kyc']['error'] = str(e)
+        return str(e)
 
-    finally:
-        return score, feedback
 
 # -------------------------------------------------------------------------- #
 #                                 Metric #1 KYC                              #
@@ -145,6 +138,8 @@ def kyc(acc, txn, feedback):
 # -------------------------------------------------------------------------- #
 
 # @measure_time_and_memory
+
+
 def history_acc_longevity(acc, feedback, duration, fico_medians):
     '''
     Description:

--- a/support/metrics_plaid.py
+++ b/support/metrics_plaid.py
@@ -160,37 +160,28 @@ def balance_now_checking_only(data, feedback):
         feedback['fetch'][balance_now_checking_only.__name__] = str(e)
 
 
-def plaid_kyc(data, feedback):
+def plaid_kyc(txn):
     '''
     Description:
         returns 1 if the oracle believes this is a legitimate user
         with some credible history. Returns 0 otherwise
 
     Parameters:
-        data (dict): Plaid 'Transactions' product
-        feedback (dict): score feedback
+        txn (dict): Plaid 'Transactions' product
 
     Returns: 
-        score (float): binary response 1|0, depending on whether the user is legitimate
-        feedback (dict): score feedback
+        (boolean): binary response 1|0, depending on whether the user is legitimate
     '''
 
     try:
-        # Pass KYC iff the account has some txn history
-        txn = data['transactions']
+        # Pass KYC if the account has some txn history
         if txn:
-            score = 1
-            feedback['credit']['verified'] = True
+            return True
         else:
-            score = 0
-            feedback['credit']['verified'] = False
+            return False
 
     except Exception as e:
-        score = 0
-        feedback['credit']['error'] = str(e)
-
-    finally:
-        return score, feedback
+        return str(e)
 
 
 # -------------------------------------------------------------------------- #

--- a/validator/coinbase.py
+++ b/validator/coinbase.py
@@ -127,5 +127,6 @@ def coinbase_accounts_and_transactions(client, currencies, txn_types):
 
     except Exception as e:
         acc = str(e)
+        txn = str(e)
 
     return acc, txn


### PR DESCRIPTION
### summary
- added kyc models for all current validators
- input:
```
    class KYC_Item(BaseModel):
    chosen_validator: str
    plaid_access_token: Optional[str]
    plaid_client_id: Optional[str]
    plaid_client_secret: Optional[str]
    coinbase_access_token: Optional[str]
    coinbase_refresh_token: Optional[str]
    coinmarketcap_key: Optional[str]
    eth_address: Optional[str]
    covalent_key: Optional[str]
```
- output:
```
    {
        'endpoint': '/credit_score/kyc',
        'status': status,
        'validator': item.chosen_validator,
        'kyc_verified': kyc_verified
    }
```
