### PR TITLE
#49 params refactor, docstrings Plaid&Cbase

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,4 +31,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          # pytest unit_tests.py
+          pytest unit_tests.py

--- a/support/metrics_coinbase.py
+++ b/support/metrics_coinbase.py
@@ -19,7 +19,7 @@ def nested_dict(d, keys, value):
 
 
 def net_flow(txn, timeframe, feedback):
-    """
+    '''
     Description:
         Returns monthly net flow (income - expenses)
 
@@ -30,7 +30,7 @@ def net_flow(txn, timeframe, feedback):
 
     Returns:
         flow (dataframe): net monthly flow by datetime
-    """
+    '''
 
     try:
         accepted_types = {
@@ -86,18 +86,19 @@ def net_flow(txn, timeframe, feedback):
 
 # @measure_time_and_memory
 def coinbase_kyc(acc, txn):
-    """
+    '''
     Description:
         returns 1 if the oracle believes this is a legitimate user
         with some credible history. Returns 0 otherwise
 
     Parameters:
-        acc (list): non-zero balance Coinbase accounts owned by the user in currencies of trusted reputation
+        acc (list): non-zero balance Coinbase accounts owned by 
+            the user in currencies of trusted reputation
         txn (list): transactions history of above-listed accounts
 
     Returns:
         (boolean): binary kyc verification 1|0
-    """
+    '''
 
     try:
         # Pass KYC check iff the Coinbase account has trusted data
@@ -117,19 +118,19 @@ def coinbase_kyc(acc, txn):
 
 # @measure_time_and_memory
 def kyc(acc, txn, feedback):
-    """
+    '''
     Description:
         A score based on Coinbase KYC verification process
 
     Parameters:
-        acc (list): non-zero balance Coinbase accounts owned by the user in currencies of trusted reputation
+        acc (list): non-zero balance Coinbase accounts owned by the user
         txn (list): transactions history of above-listed accounts
         feedback (dict): score feedback
 
     Returns:
         score (int): binary kyc verification
         feedback (dict): score feedback
-    """
+    '''
 
     try:
         # Assign max score as long as the user owns some credible non-zero balance accounts with some transaction history
@@ -156,18 +157,19 @@ def kyc(acc, txn, feedback):
 
 
 def history_acc_longevity(acc, feedback, params):
-    """
+    '''
     Description:
         A score based on the longevity of user's best Coinbase accounts
 
     Parameters:
-        acc (list): non-zero balance Coinbase accounts owned by the user in currencies of trusted reputation
+        acc (list): non-zero balance Coinbase accounts owned by the user
         feedback (dict): score feedback
+        params (dict): model parameters, i.e. coefficients
 
     Returns:
         score (float): score gained based on account longevity
         feedback (dict): score feedback
-    """
+    '''
 
     try:
         # Retrieve creation date of oldest user account
@@ -198,18 +200,19 @@ def history_acc_longevity(acc, feedback, params):
 
 # @measure_time_and_memory
 def liquidity_tot_balance_now(acc, feedback, params):
-    """
+    '''
     Description:
         A score based on cumulative balance of user's accounts
 
     Parameters:
-        acc (list): non-zero balance Coinbase accounts owned by the user in currencies of trusted reputation
+        acc (list): non-zero balance Coinbase accounts owned by the user
         feedback (dict): score feedback
+        params (dict): model parameters, i.e. coefficients
 
     Returns:
         score (float): score gained based on cumulative balance across accounts
         feedback (dict): score feedback
-    """
+    '''
 
     try:
         # Calculate tot balance now
@@ -241,17 +244,19 @@ def liquidity_tot_balance_now(acc, feedback, params):
 
 # @measure_time_and_memory
 def liquidity_loan_duedate(txn, feedback, params):
-    """
+    '''
     Description:
         returns how many months it'll take the user to pay back their loan
 
     Parameters:
         txn (list): transactions history of above-listed accounts
         feedback (dict): score feedback
+        params (dict): model parameters, i.e. coefficients
 
     Returns:
-        feedback (dict): score feedback with a new key-value pair 'loan_duedate':float (# of months in range [3,6])
-    """
+        feedback (dict): score feedback with a new key-value pair 
+            'loan_duedate':float (# of months in range [3,6])
+    '''
 
     try:
         # Read in the date of the oldest txn
@@ -275,19 +280,20 @@ def liquidity_loan_duedate(txn, feedback, params):
 
 # @measure_time_and_memory
 def liquidity_avg_running_balance(acc, txn, feedback, params):
-    """
+    '''
     Description:
         A score based on the average running balance maintained for the past 12 months
 
     Parameters:
-        acc (list): non-zero balance Coinbase accounts owned by the user in currencies of trusted reputation
+        acc (list): non-zero balance Coinbase accounts owned by the user
         txn (list): transactions history of above-listed accounts
         feedback (dict): score feedback
+        params (dict): model parameters, i.e. coefficients
 
     Returns:
         score (float): score gained for mimimum running balance
         feedback (dict): score feedback
-    """
+    '''
 
     try:
         if txn:
@@ -339,18 +345,21 @@ def liquidity_avg_running_balance(acc, txn, feedback, params):
 
 # @measure_time_and_memory
 def activity_tot_volume_tot_count(txn, type, feedback, params):
-    """
+    '''
     Description:
-        A score based on the count and volume of credit OR debit transactions across user's Coinbase accounts
+        A score based on the count and volume of credit OR 
+        debit transactions across user's Coinbase accounts
 
     Parameters:
-        txn (list): transactions history of non-zero balance Coinbase accounts owned by the user in currencies of trusted reputation
+        txn (list): transactions history of non-zero balance Coinbase accounts owned by the user
         type (str): accepts 'credit' or 'debit'
+        feedback (dict): score feedback
+        params (dict): model parameters, i.e. coefficients
 
     Returns:
         score (float): score gained for count and volume of credit transactions
         feedback (dict): score feedback
-    """
+    '''
 
     try:
         # Calculate total volume of credit OR debit and txn counts
@@ -386,18 +395,20 @@ def activity_tot_volume_tot_count(txn, type, feedback, params):
 
 # @measure_time_and_memory
 def activity_consistency(txn, type, feedback, params):
-    """
+    '''
     Description:
         A score based on the the weigthed monthly average credit OR debit volume over time
 
     Parameters:
-        txn (list): transactions history of non-zero balance Coinbase accounts owned by the user in currencies of trusted reputation
+        txn (list): transactions history of non-zero balance Coinbase accounts owned by the user
         type (str): accepts 'credit' or 'debit'
+        feedback (dict): score feedback
+        params (dict): model parameters, i.e. coefficients
 
     Returns:
         score (float): score for consistency of credit OR debit weighted avg monthly volume
         feedback (dict): score feedback
-    """
+    '''
 
     try:
         if txn:
@@ -456,19 +467,21 @@ def activity_consistency(txn, type, feedback, params):
 
 # @measure_time_and_memory
 def activity_profit_since_inception(acc, txn, feedback, params):
-    """
+    '''
     Description:
         A score based on total user profit since account inception. We define net profit as:
-            net profit = (tot withdrawals) + (tot Coinbase balance now) - (tot injections into your wallet)
+        net profit = (tot withdrawals) + (tot Coinbase balance now) - (tot injections into your wallet)
 
     Parameters:
-        acc (list): non-zero balance Coinbase accounts owned by the user in currencies of trusted reputation
+        acc (list): non-zero balance Coinbase accounts owned by the user
         txn (list): transaction history of above-listed accounts
+        feedback (dict): score feedback
+        params (dict): model parameters, i.e. coefficients
 
     Returns:
         score (int): for user total net profit thus far
         feedback (dict): score feedback
-    """
+    '''
 
     try:
         accepted_types = {

--- a/support/models.py
+++ b/support/models.py
@@ -133,7 +133,7 @@ def covalent_credibility(txn, balances, portfolio, feedback, weights, params):
     kyc, feedback = credibility_kyc(txn, balances, feedback)
 
     inception, feedback = credibility_oldest_txn(
-        txn, feedback, params["fico_medians"], params["duration"]
+        txn, feedback, params
     )
 
     a = list(weights.values())[:2]
@@ -147,15 +147,15 @@ def covalent_credibility(txn, balances, portfolio, feedback, weights, params):
 def covalent_wealth(txn, balances, feedback, weights, params, erc_rank):
 
     capital_now, feedback = wealth_capital_now(
-        balances, feedback, params["fico_medians"], params["volume_now"]
+        balances, feedback, params
     )
 
     capital_now_adj, feedback = wealth_capital_now_adjusted(
-        balances, feedback, erc_rank, params["fico_medians"], params["volume_now"]
+        balances, feedback, erc_rank, params
     )
 
     volume_per_txn, feedback = wealth_volume_per_txn(
-        txn, feedback, params["fico_medians"], params["volume_per_txn"]
+        txn, feedback, params
     )
 
     a = list(weights.values())[2:5]
@@ -172,28 +172,24 @@ def covalent_traffic(txn, portfolio, feedback, weights, params, erc_rank):
         txn,
         feedback,
         "credit",
-        params["count_operations"],
-        params["cred_deb"],
-        params["mtx_traffic"],
+        params
     )
 
     debit, feedback = traffic_cred_deb(
         txn,
         feedback,
         "debit",
-        params["count_operations"],
-        params["cred_deb"],
-        params["mtx_traffic"],
+        params
     )
 
-    dust, feedback = traffic_dustiness(txn, feedback, params["fico_medians"])
+    dust, feedback = traffic_dustiness(txn, feedback, params)
 
     run_balance, feedback = traffic_running_balance(
-        portfolio, feedback, params["fico_medians"], params["avg_run_bal"], erc_rank
+        portfolio, feedback, params, erc_rank
     )
 
     frequency, feedback = traffic_frequency(
-        txn, feedback, params["fico_medians"], params["frequency_txn"]
+        txn, feedback, params
     )
 
     a = list(weights.values())[5:10]
@@ -209,29 +205,23 @@ def covalent_stamina(txn, balances, portfolio, feedback, weights, params, erc_ra
     methods, feedback = stamina_methods_count(
         txn,
         feedback,
-        params["count_to_four"],
-        params["volume_now"],
-        params["mtx_stamina"],
+        params
     )
 
     coins, feedback = stamina_coins_count(
         balances,
         feedback,
-        params["count_to_four"],
-        params["volume_now"],
-        params["mtx_stamina"],
-        erc_rank,
+        params,
+        erc_rank
     )
 
     dexterity, feedback = stamina_dexterity(
         portfolio,
         feedback,
-        params["count_to_four"],
-        params["volume_now"],
-        params["mtx_stamina"],
+        params
     )
 
-    feedback = stamina_loan_duedate(txn, feedback, params["due_date"])
+    feedback = stamina_loan_duedate(txn, feedback, params)
 
     a = list(weights.values())[10:]
     b = [coins, methods, dexterity]

--- a/testing/tests/test_coinbase.py
+++ b/testing/tests/test_coinbase.py
@@ -96,17 +96,17 @@ class TestMetricsCoinbase(unittest.TestCase):
         - variable 'age' should be a non-negative of type: int or float
         - if there's no account, the score should be 0
         '''
-        history_acc_longevity(self.acc, self.fb, self.par[1], self.par[7])
+        history_acc_longevity(self.acc, self.fb, self.par)
 
         self.assertGreaterEqual(history_acc_longevity.age, 0)
         self.assertIsInstance(history_acc_longevity.age, (int, float))
-        self.assertEqual(history_acc_longevity([], self.fb, self.par[1], self.par[7])[0], 0)
+        self.assertEqual(history_acc_longevity([], self.fb, self.par)[0], 0)
 
     def test_liquidity_tot_balance_now(self):
         '''
         - empty account should result in 'no balance' error
         '''
-        self.assertRegex(liquidity_tot_balance_now([], self.fb, self.par[2], self.par[7])[
+        self.assertRegex(liquidity_tot_balance_now([], self.fb, self.par)[
                          1]['liquidity']['error'], 'no balance')
 
     def test_liquidity_loan_duedate(self):
@@ -114,15 +114,15 @@ class TestMetricsCoinbase(unittest.TestCase):
         - duedate should be at most 6 months
         - this is the only function that returns no score, but rather, it returns only the feedback dict
         '''
-        self.assertLessEqual(liquidity_loan_duedate(self.tx, self.fb, self.par[0])[
+        self.assertLessEqual(liquidity_loan_duedate(self.tx, self.fb, self.par)[
                              'liquidity']['loan_duedate'], 6)
-        self.assertIsInstance(liquidity_loan_duedate(self.tx, self.fb, self.par[0]), dict)
+        self.assertIsInstance(liquidity_loan_duedate(self.tx, self.fb, self.par), dict)
 
     def test_liquidity_avg_running_balance(self):
         '''
         - no tx yields a 'no tx' error
         '''
-        self.assertRegex(liquidity_avg_running_balance(self.acc, [], self.fb, self.par[1], self.par[2], self.par[6])[
+        self.assertRegex(liquidity_avg_running_balance(self.acc, [], self.fb, self.par)[
                          1]['liquidity']['error'], 'no transaction history')
 
     def test_activity_tot_volume_tot_count(self):
@@ -133,8 +133,8 @@ class TestMetricsCoinbase(unittest.TestCase):
         - no tx returns 'no tx history' error
         '''
         fb = {'kyc': {}, 'history': {}, 'liquidity': {}, 'activity': {}}
-        cred, cred_fb = activity_tot_volume_tot_count(self.tx, 'credit', fb, self.par[2], self.par[4], self.par[5])
-        deb, deb_fb = activity_tot_volume_tot_count(self.tx, 'debit', fb, self.par[2], self.par[4], self.par[5])
+        cred, cred_fb = activity_tot_volume_tot_count(self.tx, 'credit', fb, self.par)
+        deb, deb_fb = activity_tot_volume_tot_count(self.tx, 'debit', fb, self.par)
 
         for a in [cred, deb]:
             self.assertIsInstance(a, (float, int))
@@ -142,7 +142,7 @@ class TestMetricsCoinbase(unittest.TestCase):
 
         self.assertEqual(cred_fb['activity'].get(
             'credit').keys(), deb_fb['activity'].get('debit').keys())
-        self.assertRegex(activity_tot_volume_tot_count([], 'credit', self.fb, self.par[2], self.par[4], self.par[5])[
+        self.assertRegex(activity_tot_volume_tot_count([], 'credit', self.fb, self.par)[
                          1]['activity']['error'], 'no transaction history')
 
     def test_activity_consistency(self):
@@ -152,14 +152,14 @@ class TestMetricsCoinbase(unittest.TestCase):
         - avg volume should be a positive number
         - no tx returns 'no tx history' error
         '''
-        a, b = activity_consistency(self.tx, 'credit', self.fb, self.par[1], self.par[3], self.par[6])
+        a, b = activity_consistency(self.tx, 'credit', self.fb, self.par)
         i = list(activity_consistency.frame.index)
         d = [x[0] for x in activity_consistency.typed_txn]
 
         self.assertCountEqual(i, d)
         self.assertIsInstance(np.random.choice(d), datetime)
         self.assertGreater(a, 0)
-        self.assertRegex(activity_consistency([], 'credit', self.fb, self.par[1], self.par[3], self.par[6])[
+        self.assertRegex(activity_consistency([], 'credit', self.fb, self.par)[
                          1]['activity']['error'], 'no transaction history')
 
     def test_activity_profit_since_inception(self):
@@ -168,12 +168,12 @@ class TestMetricsCoinbase(unittest.TestCase):
         - 'profit' should be positive
         - if there's no profit, then should raise an exception
         '''
-        activity_profit_since_inception(self.acc, self.tx, self.fb, self.par[3], self.par[7])
+        activity_profit_since_inception(self.acc, self.tx, self.fb, self.par)
 
         self.assertIsInstance(
             activity_profit_since_inception.profit, (float, int))
         self.assertGreater(activity_profit_since_inception.profit, 0)
-        self.assertRegex(activity_profit_since_inception([], [], self.fb, self.par[3], self.par[7])[
+        self.assertRegex(activity_profit_since_inception([], [], self.fb, self.par)[
                          1]['activity']['error'], 'no net profit')
 
     def test_net_flow(self):
@@ -230,44 +230,32 @@ class TestParametrizeCoinbase(unittest.TestCase):
         params = configs['minimum_requirements']['coinbase']['params']
         self.par = coinbase_params(params, score_range) 
     
-        self.args1 = {
+        self.args = {
             'good': 
             [
                 [self.acc, self.tx, self.fb],
-                [self.acc, self.fb],
-                [self.acc, self.tx, self.fb],
-                [self.acc, self.fb],
-                [self.tx, 'credit', self.fb],
-                [self.tx, 'debit', self.fb],
-                [self.tx, 'credit', self.fb],
-                [self.tx, 'debit', self.fb],
-                [self.acc, self.tx, self.fb]
+                [self.acc, self.fb, self.par],
+                [self.acc, self.tx, self.fb, self.par],
+                [self.acc, self.fb, self.par],
+                [self.tx, 'credit', self.fb, self.par],
+                [self.tx, 'debit', self.fb, self.par],
+                [self.tx, 'credit', self.fb, self.par],
+                [self.tx, 'debit', self.fb, self.par],
+                [self.acc, self.tx, self.fb, self.par]
             ],
             'empty': 
             [
                 [[], None, self.fb],
-                [None, self.fb],
-                [[], [], self.fb],
-                [None, self.fb],
-                [[], None, self.fb],
-                [[], [], self.fb],
-                [[], None, self.fb],
-                [None, [], self.fb],
-                [None, None, self.fb]
+                [None, self.fb, self.par],
+                [[], [], self.fb, self.par],
+                [None, self.fb, self.par],
+                [[], None, self.fb, self.par],
+                [[], [], self.fb, self.par],
+                [[], None, self.fb, self.par],
+                [None, [], self.fb, self.par],
+                [None, None, self.fb, self.par]
             ]
         }
-
-        self.args2 = [
-            list(),
-            [self.par[1], self.par[7]],
-            [self.par[1], self.par[2], self.par[6]],
-            [self.par[2], self.par[7]],
-            [self.par[1], self.par[3], self.par[6]],
-            [self.par[1], self.par[3], self.par[6]],
-            [self.par[2], self.par[4], self.par[5]],
-            [self.par[2], self.par[4], self.par[5]],
-            [self.par[3], self.par[7]],
-        ]
 
         self.fn = {
             'all': [
@@ -284,12 +272,12 @@ class TestParametrizeCoinbase(unittest.TestCase):
         }
 
     def tearDown(self):
-        for y in [self.fb, self.acc, self.tx, self.par, self.args1, self.args2, self.fn]:
+        for y in [self.fb, self.acc, self.tx, self.par, self.args, self.fn]:
             y = None
 
     def test_output_good(self):
-        for (f, a, b) in zip(self.fn['all'], self.args1['good'], self.args2):
-            x = f(*a, *b)
+        for (f, a) in zip(self.fn['all'], self.args['good']):
+            x = f(*a)
             with self.subTest():
                 self.assertIsInstance(x, tuple)
                 self.assertLessEqual(x[0], 1)
@@ -297,8 +285,8 @@ class TestParametrizeCoinbase(unittest.TestCase):
                 self.assertIsInstance(x[1], dict)
 
     def test_output_empty(self):
-        for (f, a, b) in zip(self.fn['all'], self.args1['empty'], self.args2):
-            x = f(*a, *b)
+        for (f, a) in zip(self.fn['all'], self.args['empty']):
+            x = f(*a)
             with self.subTest():
                 self.assertIsInstance(x, tuple)
                 self.assertEqual(x[0], 0)

--- a/testing/tests/test_covalent.py
+++ b/testing/tests/test_covalent.py
@@ -58,17 +58,16 @@ class TestMetricCredibility(unittest.TestCase):
         length = credibility_oldest_txn(
             self.txn, 
             self.fb, 
-            self.parm['fico_medians'], 
-            self.parm['duration']
+            self.parm
             )
 
         if length[1]['credibility']['longevity(days)'] >= 270: #days
             self.assertEqual(length[0], 1)
 
         self.assertRaises(
-            Exception, 
+            Exception,
             credibility_oldest_txn, 
-            ({}, self.fb, self.parm['fico_medians'], self.parm['duration'])
+            ({}, self.fb, self.parm)
             )
 
 
@@ -103,20 +102,19 @@ class TestMetricWealth(unittest.TestCase):
         # cumulative capital now should match the sum of all balances now
         tot = sum([b['quote'] for b in self.bal['items']])
         tot_bal = wealth_capital_now(
-            self.bal, self.fb, self.parm['fico_medians'], self.parm['volume_now']
+            self.bal, self.fb, self.parm
             )
 
         self.assertEqual(int(tot_bal[1]['wealth']['cum_balance_now']), int(tot))
         self.assertIn('error', wealth_capital_now({}, 
             self.fb, 
-            self.parm['fico_medians'], 
-            self.parm['volume_now'])[1]['wealth']
+            self.parm)[1]['wealth']
             )
         self.bal['quote_currency'] = 'EUR'
         self.assertRaises(
             Exception, 
             wealth_capital_now, 
-            (self.bal, self.fb, self.parm['fico_medians'], self.parm['volume_now']) 
+            (self.bal, self.fb, self.parm) 
             )
 
     def test_wealth_capital_now_adjusted(self):
@@ -125,8 +123,7 @@ class TestMetricWealth(unittest.TestCase):
             self.bal,
             self.fb,
             ERC_RANK,
-            self.parm['fico_medians'],
-            self.parm['volume_now']
+            self.parm
         )
         keep_erc = [b['contract_ticker_symbol'] for b in wealth_capital_now_adjusted.top['items']]
         for erc in keep_erc:
@@ -141,12 +138,11 @@ class TestMetricWealth(unittest.TestCase):
         avg1 = wealth_volume_per_txn(
             self.txn,
             self.fb,
-            self.parm['fico_medians'],
-            self.parm['volume_per_txn']
+            self.parm
             )
         self.assertEqual(int(avg1[1]['wealth']['avg_volume_per_txn']), int(avg0))
         self.assertEqual(
-            wealth_volume_per_txn({}, self.fb, self.parm['fico_medians'], self.parm['volume_per_txn'])[0], 0)
+            wealth_volume_per_txn({}, self.fb, self.parm)[0], 0)
         self.assertRaises(Exception, wealth_volume_per_txn, ({}, self.fb, {}, None))
 
 
@@ -186,27 +182,23 @@ class TestMetricTraffic(unittest.TestCase):
             self.txn,
             self.fb,
             'credit',
-            self.parm['count_operations'],
-            self.parm['cred_deb'],
-            self.parm['mtx_traffic']
+            self.parm
         )
         self.assertTrue('volume_credit_txns' in list(out[1]['traffic'].keys()))
         self.assertRaises(Exception, traffic_cred_deb, traffic_cred_deb(
             self.txn,
             self.fb,
             'swap',
-            self.parm['count_operations'],
-            self.parm['cred_deb'],
-            self.parm['mtx_traffic']
+            self.parm
         ), "you passed an invalid param: accepts only 'credit', 'debit', or 'transfer'")
 
 
     def test_traffic_dustiness(self):
         # when all txn are voluminous, the user should earn the max score of 1
         if len(swiffer_duster(self.txn, self.fb)['items']) == len(self.txn['items']):
-            self.assertEqual(traffic_dustiness(self.txn, self.fb, self.parm['fico_medians'])[0], 1)
+            self.assertEqual(traffic_dustiness(self.txn, self.fb, self.parm)[0], 1)
         self.assertIn('error',
-            list(traffic_dustiness(self.bal, self.fb, self.parm['fico_medians'])[1]['traffic'].keys())
+            list(traffic_dustiness(self.bal, self.fb, self.parm)[1]['traffic'].keys())
             )
 
     def test_traffic_running_balance(self):
@@ -214,8 +206,7 @@ class TestMetricTraffic(unittest.TestCase):
         a = traffic_running_balance(
             self.por,
             self.fb,
-            self.parm['fico_medians'],
-            self.parm['avg_run_bal'],
+            self.parm,
             ERC_RANK
             )
         quotes = [y['close']['quote'] for x in self.por['items'] for y in x['holdings']\
@@ -226,7 +217,7 @@ class TestMetricTraffic(unittest.TestCase):
 
     def test_traffic_frequency(self):
         # score > 0.5 when monthly_txn_frequency > 0.5
-        a = traffic_frequency(self.txn, self.fb, self.parm['fico_medians'], self.parm['frequency_txn'])
+        a = traffic_frequency(self.txn, self.fb, self.parm)
         frequency = float(a[1]['traffic']['txn_frequency'].split(' ')[0])
         if frequency > 0.5:
             self.assertGreater(a[0], 0.5)
@@ -269,9 +260,7 @@ class TestMetricStamina(unittest.TestCase):
         stamina_methods_count(
             self.txn,
             self.fb,
-            self.parm['count_to_four'],
-            self.parm['volume_now'],
-            self.parm['mtx_stamina']
+            self.parm
         )
         methods = list(set([t['log_events'][0]['decoded']['name']\
             for t in self.txn['items'] if t['log_events']]))
@@ -283,9 +272,7 @@ class TestMetricStamina(unittest.TestCase):
         stamina_coins_count(
             self.bal,
             self.fb,
-            self.parm['count_to_four'],
-            self.parm['volume_now'],
-            self.parm['mtx_stamina'],
+            self.parm,
             ERC_RANK
             )
         coins = [c['contract_ticker_symbol'] for c in self.bal['items']\
@@ -298,9 +285,7 @@ class TestMetricStamina(unittest.TestCase):
             (
                 self.txn,
                 self.fb,
-                self.parm['count_to_four'],
-                self.parm['volume_now'],
-                self.parm['mtx_stamina'],
+                self.parm,
                 ERC_RANK
             )
         )
@@ -310,9 +295,7 @@ class TestMetricStamina(unittest.TestCase):
         smart_trades = stamina_dexterity(
             self.por, 
             self.fb, 
-            self.parm['count_to_four'], 
-            self.parm['volume_now'], 
-            self.parm['mtx_stamina']
+            self.parm,
             )
         self.assertIsInstance(smart_trades[1]['stamina']['count_smart_trades'], int)
         self.assertRaises(Exception, stamina_dexterity, ({}, self.fb, None, None, None))
@@ -323,13 +306,12 @@ class TestMetricStamina(unittest.TestCase):
         longevity = credibility_oldest_txn(
             self.txn, 
             self.fb, 
-            self.parm['fico_medians'], 
-            self.parm['duration']
+            self.parm,
             )[1]['credibility']['longevity(days)']
         duedate = stamina_loan_duedate(
             self.txn,
             self.fb,
-            self.parm['due_date']
+            self.parm
             )['stamina']['loan_duedate']
 
         self.assertGreater(longevity/30, duedate)
@@ -471,18 +453,18 @@ class TestParametrizeCovalent(unittest.TestCase):
 
         self.args2 = [
             list(),
-            [self.parm['fico_medians'], self.parm['duration']],
-            [self.parm['fico_medians'], self.parm['volume_now']],
-            [ERC_RANK, self.parm['fico_medians'], self.parm['volume_now']],
-            [self.parm['fico_medians'], self.parm['volume_per_txn']],
-            ['credit', self.parm['count_operations'], self.parm['cred_deb'], self.parm['mtx_traffic']],
-            ['debit', self.parm['count_operations'], self.parm['cred_deb'], self.parm['mtx_traffic']],
-            [self.parm['fico_medians']],
-            [self.parm['fico_medians'], self.parm['avg_run_bal'], ERC_RANK],
-            [self.parm['fico_medians'], self.parm['frequency_txn']],
-            [self.parm['count_to_four'], self.parm['volume_now'], self.parm['mtx_stamina']],
-            [self.parm['count_to_four'], self.parm['volume_now'], self.parm['mtx_stamina'], ERC_RANK],
-            [self.parm['count_to_four'], self.parm['volume_now'], self.parm['mtx_stamina']]
+            [self.parm],
+            [self.parm],
+            [ERC_RANK, self.parm],
+            [self.parm],
+            ['credit', self.parm],
+            ['debit', self.parm],
+            [self.parm],
+            [self.parm, ERC_RANK],
+            [self.parm],
+            [self.parm],
+            [self.parm, ERC_RANK],
+            [self.parm],
         ]
 
         self.fn = {

--- a/testing/tests/test_plaid.py
+++ b/testing/tests/test_plaid.py
@@ -63,7 +63,12 @@ class TestMetricCredit(unittest.TestCase):
         self.fb['fetch'] = {}
 
         with open(json_file) as f:
-            self.data = str_to_datetime(json.load(f), self.fb)
+            data = str_to_datetime(json.load(f), self.fb)
+        self.acc = data['accounts']
+        txn = data['transactions']
+        txn = merge_dict(txn, self.acc, "account_id", ["type", "subtype"])
+        self.txn = sorted(txn, key=lambda d: d["date"])
+        self.cred = [d for d in self.acc if d["type"].lower() == "credit"]
 
         # import params
         score_range = configs['score_range']
@@ -73,7 +78,9 @@ class TestMetricCredit(unittest.TestCase):
     # clean up code at the end of this test class
     def tearDown(self):
         self.fb = None
-        self.data = None
+        self.acc = None
+        self.txn = None
+        self.cred = None
         self.par =  None
 
     def test_credit_mix(self):
@@ -82,18 +89,19 @@ class TestMetricCredit(unittest.TestCase):
         - ensure we store the names of ALL owned credit cards
         - if a user owns no credit card, then raise exception 'no credit card'
         '''
-        self.assertNotIn('credit', credit_mix(self.data, self.fb, self.par[1], self.par[2], self.par[11]))
+        a = credit_mix(self.txn, self.cred, self.fb, self.par)
+        self.assertNotIn('credit', a)
         self.assertEqual(len(credit_mix.credit), len(credit_mix.card_names))
-        self.assertIn('error', credit_mix([], self.fb, self.par[1], self.par[2], self.par[11])[1]['credit'].keys())
+        self.assertIn('error', credit_mix(self.txn, [], self.fb, self.par)[1]['credit'].keys())
 
     def test_credit_limit(self):
         '''
         - return a float for the credit limit
         - if a user's credit limit is not defined, then raise exception
         '''
-        self.assertIsInstance(credit_limit(self.data, self.fb, self.par[1], self.par[4], self.par[10])[
+        self.assertIsInstance(credit_limit(self.txn, self.cred, self.fb, self.par)[
                               1]['credit']['credit_limit'], (float, int))
-        self.assertIn('error', credit_limit([], self.fb, self.par[1], self.par[4], self.par[10])[1]['credit'].keys())
+        self.assertIn('error', credit_limit([], self.cred, self.fb, self.par)[1]['credit'].keys())
 
     def test_credit_util_ratio(self):
         '''
@@ -101,26 +109,26 @@ class TestMetricCredit(unittest.TestCase):
         - the credit util ration should be at most 2 (if exceeds this upper bound, then something's wrong)
         - ensure bad data returns an error
         '''
-        a = credit_util_ratio(self.data, self.fb, self.par[1], self.par[21], self.par[11])
+        a = credit_util_ratio(self.acc, self.txn, self.fb, self.par)
 
-        if dynamic_select(self.data, 'credit', self.fb)['id'] != 'inexistent':
+        if dynamic_select(self.acc, self.txn, 'credit', self.fb)['id'] != 'inexistent':
             self.assertIn('utilization_ratio', a[1]['credit'].keys())
             self.assertIsInstance(
                 a[1]['credit']['utilization_ratio'], (float, int))
             self.assertGreaterEqual(a[0], 0.3)
         self.assertLess(a[0], 2)
 
-        self.assertIn('error', credit_util_ratio(
-            [], self.fb, self.par[1], self.par[21], self.par[11])[1]['credit'].keys())
+        self.assertEqual(credit_util_ratio(
+            [], [], self.fb, self.par)[0], 0)
 
     def test_credit_interest(self):
         '''
         - Plaid Sandbox data has an impeccable credit card pedigree and thus should score 1/1
         - bad data should raise an exception because the dynamic_select() function will break
         '''
-        self.assertEqual(credit_interest(self.data, self.fb, self.par[14], self.par[22])[0], 1)
+        self.assertEqual(credit_interest(self.acc, self.txn, self.fb, self.par)[0], 1)
         self.assertIn('dynamic_select',  credit_interest(
-            [], self.fb, self.par[14], self.par[22])[1]['fetch'].keys())
+            None, None, self.fb, self.par)[1]['fetch'].keys())
 
     def test_credit_length(self):
         '''
@@ -128,24 +136,24 @@ class TestMetricCredit(unittest.TestCase):
         - if a credit card exists, then there should be a positive length
         - bad data should raise an exception
         '''
-        a = credit_length(self.data, self.fb, self.par[14], self.par[1])
+        a = credit_length(self.acc, self.txn, self.fb, self.par)
 
-        if dynamic_select(self.data, 'credit', self.fb)['id']:
+        if dynamic_select(self.acc, self.txn, 'credit', self.fb)['id']:
             self.assertIsInstance(
                 a[1]['credit']['credit_duration_(days)'], (float, int))
             self.assertGreater(a[1]['credit']['credit_duration_(days)'], 0)
-        self.assertIn('error', credit_length([], self.fb, self.par[14], self.par[1])[1]['credit'].keys())
+        self.assertIn('error', credit_length([], [], self.fb, self.par)[1]['credit'].keys())
 
     def test_credit_livelihood(self):
         '''
         - if there exist a non-empty dataframe containing the txn means, then the mean should be positive
         - bad data should raise an error
         '''
-        a = credit_livelihood(self.data, self.fb, self.par[14], self.par[15])
+        a = credit_livelihood(self.acc, self.txn, self.fb, self.par)
         if len(credit_livelihood.d):
             self.assertGreater(a[1]['credit']['avg_count_monthly_txn'], 0)
         self.assertIn('error', credit_livelihood(
-            [], self.fb, self.par[14], self.par[15])[1]['credit'].keys())
+            [], [], self.fb, self.par)[1]['credit'].keys())
 
 
 class TestMetricVelocity(unittest.TestCase):
@@ -161,7 +169,11 @@ class TestMetricVelocity(unittest.TestCase):
         self.fb['fetch'] = {}
 
         with open(json_file) as f:
-            self.data = str_to_datetime(json.load(f), self.fb)
+            data = str_to_datetime(json.load(f), self.fb)
+        self.acc = data['accounts']
+        txn = data['transactions']
+        txn = merge_dict(txn, self.acc, "account_id", ["type", "subtype"])
+        self.txn = sorted(txn, key=lambda d: d["date"])
 
         # import params
         score_range = configs['score_range']
@@ -171,7 +183,8 @@ class TestMetricVelocity(unittest.TestCase):
     # clean up code at the end of this test class
     def tearDown(self):
         self.fb = None
-        self.data = None
+        self.acc = None
+        self.txn = None
         self.par =  None
 
     def test_velocity_withdrawals(self):
@@ -180,20 +193,20 @@ class TestMetricVelocity(unittest.TestCase):
         - good data but without withdrawals raises the 'no withdrawals' exception
         - bad data returns an error
         '''
-        self.assertIsNone(velocity_withdrawals(self.data, None, self.par[2], self.par[18], self.par[13])[1])
-        self.assertRegex(velocity_withdrawals(self.data, self.fb, self.par[2], self.par[18], self.par[13])[
+        self.assertIsNone(velocity_withdrawals(self.txn, None, self.par)[1])
+        self.assertRegex(velocity_withdrawals(self.txn, self.fb, self.par)[
                          1]['velocity']['error'], 'no withdrawals')
         self.assertIn('error', velocity_withdrawals(
-            [], self.fb, self.par[2], self.par[18], self.par[13])[1]['velocity'].keys())
+            [], self.fb, self.par)[1]['velocity'].keys())
 
     def test_velocity_deposits(self):
         '''
         - if there are some 'payroll' trasactions, then the score should be positive
         - bad data returns an error
         '''
-        a = velocity_deposits(self.data, self.fb, self.par[2], self.par[19], self.par[13])
+        a = velocity_deposits(self.txn, self.fb, self.par)
 
-        if [t for t in self.data['transactions'] if t['amount'] < -200 and 'payroll' in [x.lower() for x in t['category']]]:
+        if [t for t in self.txn if t['amount'] < -200 and 'payroll' in [x.lower() for x in t['category']]]:
             self.assertGreater(a[0], 0)
         self.assertRegex(a[1]['velocity']['error'], 'no deposits')
 
@@ -202,20 +215,20 @@ class TestMetricVelocity(unittest.TestCase):
         - the avg net flow should be a large positive integer
         - bad input data results into an error
         '''
-        self.assertGreater(velocity_month_net_flow(self.data, self.fb, self.par[7], self.par[17], self.par[10])[
+        self.assertGreater(velocity_month_net_flow(self.acc, self.txn, self.fb, self.par)[
                            1]['velocity']['avg_net_flow'], 0)
         self.assertIn('error', velocity_month_net_flow(
-            [], self.fb, self.par[7], self.par[17], self.par[10])[1]['velocity'].keys())
+            [], self.txn, self.fb, self.par)[1]['velocity'].keys())
 
     def test_velocity_month_txn_count(self):
         '''
         - if there is a legit checking account, then the score should be positive
         '''
         checking_acc = [a['account_id']
-                        for a in self.data['accounts'] if a['subtype'].lower() == 'checking']
-        if [t for t in self.data['transactions'] if t['account_id'] in checking_acc]:
+                        for a in self.acc if a['subtype'].lower() == 'checking']
+        if [t for t in self.txn if t['account_id'] in checking_acc]:
             self.assertGreater(velocity_month_txn_count(
-                self.data, self.fb, self.par[14], self.par[16])[0], 0)
+                self.acc, self.txn, self.fb, self.par)[0], 0)
 
     def test_velocity_slope(self):
         '''
@@ -223,15 +236,15 @@ class TestMetricVelocity(unittest.TestCase):
             otherwise it'll simply calculate the monthly flow as 2 rations
         - bad input data returns error
         '''
-        if len(flows(self.data, 24, self.fb)) >= 10:
+        if len(flows(self.acc, self.txn, 24, self.fb)) >= 10:
             self.assertIn('slope', velocity_slope(
-                self.data, self.fb, self.par[14], self.par[9], self.par[8], self.par[10])[1]['velocity'].keys())
+                self.acc, self.txn, self.fb, self.par)[1]['velocity'].keys())
         else:
             self.assertIn('monthly_flow', velocity_slope(
-                self.data, self.fb, self.par[14], self.par[9], self.par[8], self.par[10])[1]['velocity'].keys())
+                self.acc, self.txn, self.fb, self.par)[1]['velocity'].keys())
 
         self.assertIn('error', velocity_slope(
-            [], self.fb, self.par[14], self.par[9], self.par[8], self.par[10])[1]['velocity'].keys())
+            [], self.txn, self.fb, self.par)[1]['velocity'].keys())
 
 
 class TestMetricStability(unittest.TestCase):
@@ -247,7 +260,13 @@ class TestMetricStability(unittest.TestCase):
         self.fb['fetch'] = {}
 
         with open(json_file) as f:
-            self.data = str_to_datetime(json.load(f), self.fb)
+            data = str_to_datetime(json.load(f), self.fb)
+        self.acc = data['accounts']
+        txn = data['transactions']
+        txn = merge_dict(txn, self.acc, "account_id", ["type", "subtype"])
+        self.txn = sorted(txn, key=lambda d: d["date"])
+        self.dep = [d for d in self.acc if d["type"].lower() == "depository"]
+        self.n_dep = [d for d in self.acc if d["type"].lower() != "depository"]
 
         # import params
         score_range = configs['score_range']
@@ -257,7 +276,10 @@ class TestMetricStability(unittest.TestCase):
     # clean up code at the end of this test class
     def tearDown(self):
         self.fb = None
-        self.data = None
+        self.acc = None
+        self.txn = None
+        self.dep = None
+        self.n_dep = None
         self.par =  None
 
     def test_stability_tot_balance_now(self):
@@ -265,12 +287,12 @@ class TestMetricStability(unittest.TestCase):
         - if tot balance variable exists, then the score should be > 0
         - no account data returns an error
         '''
-        a = stability_tot_balance_now(self.data, self.fb, self.par[14], self.par[6])
+        a = stability_tot_balance_now(self.dep, self.n_dep, self.fb, self.par)
 
         if stability_tot_balance_now.balance:
             self.assertGreater(a[0], 0)
         self.assertIn('error', stability_tot_balance_now(
-            [], self.fb, self.par[14], self.par[6])[1]['stability'].keys())
+            [], self.n_dep, self.fb, self.par)[1]['stability'].keys())
 
     def test_stability_min_running_balance(self):
         '''
@@ -278,13 +300,13 @@ class TestMetricStability(unittest.TestCase):
         - good data should return 2 dict keys under the 'stability' scope of the 'feedback' dict
         - bad input data should return error
         '''
-        a = stability_min_running_balance(self.data, self.fb, self.par[1], self.par[20], self.par[11])
+        a = stability_min_running_balance(self.acc, self.txn, self.fb, self.par)
 
         self.assertIsInstance(a[1]['stability']['min_running_timeframe'], int)
         self.assertEqual(['min_running' in x for x in a[1]
                          ['stability']].count(True), 2)
         self.assertIn('error', stability_min_running_balance(
-            [], self.fb, self.par[1], self.par[20], self.par[11])[1]['stability'].keys())
+            [], self.txn, self.fb, self.par)[1]['stability'].keys())
 
     def test_stability_loan_duedate(self):
         '''
@@ -292,10 +314,10 @@ class TestMetricStability(unittest.TestCase):
         - the max allowed loan duedate is 6 months
         - feeding NoneTypes as function parameters should still return a feedback dict containing an error message
         '''
-        a = stability_loan_duedate(self.data, self.fb, self.par[0])
+        a = stability_loan_duedate(self.txn, self.fb, self.par)
         self.assertIsInstance(a, dict)
         self.assertLessEqual(a['stability']['loan_duedate'], 6)
-        self.assertRegex(stability_loan_duedate(None, self.fb, self.par[0])[
+        self.assertRegex(stability_loan_duedate(None, self.fb, self.par)[
                          'stability']['error'], "'NoneType' object is not subscriptable")
 
 
@@ -312,7 +334,11 @@ class TestMetricDiversity(unittest.TestCase):
         self.fb['fetch'] = {}
 
         with open(json_file) as f:
-            self.data = str_to_datetime(json.load(f), self.fb)
+            data = str_to_datetime(json.load(f), self.fb)
+        self.acc = data['accounts']
+        txn = data['transactions']
+        txn = merge_dict(txn, self.acc, "account_id", ["type", "subtype"])
+        self.txn = sorted(txn, key=lambda d: d["date"])
 
         # import params
         score_range = configs['score_range']
@@ -322,7 +348,8 @@ class TestMetricDiversity(unittest.TestCase):
     # clean up code at the end of this test class
     def tearDown(self):
         self.fb = None
-        self.data = None
+        self.acc = None
+        self.txn = None
         self.par =  None
 
     def test_diversity_acc_count(self):
@@ -331,14 +358,14 @@ class TestMetricDiversity(unittest.TestCase):
         - users with at least 2 accounts get a positive score
         - missing data raises an exception
         '''
-        a = diversity_acc_count(self.data, self.fb, self.par[2], self.par[1], self.par[13])
+        a = diversity_acc_count(self.acc, self.txn, self.fb, self.par)
 
-        if (datetime.now().date() - self.data['transactions'][-1]['date']).days > 120:
+        if (datetime.now().date() - self.txn[-1]['date']).days > 120:
             self.assertGreater(a[0], 0.25)
-        if len(self.data['accounts']) >= 2:
+        if len(self.acc) >= 2:
             self.assertGreater(a[0], 0)
         self.assertRaises(TypeError, 'tuple indices must be integers or slices, not str',
-                          diversity_acc_count, (None, self.fb, self.par[2], self.par[1], self.par[13]))
+                          diversity_acc_count, (None, self.txn, self.fb, self.par))
 
     def test_diversity_profile(self):
         '''
@@ -347,10 +374,10 @@ class TestMetricDiversity(unittest.TestCase):
         '''
         bonus_acc = ['401k', 'cd', 'money market', 'mortgage', 'student', 'isa', 'ebt', 'non-taxable brokerage account', 'rdsp', 'rrif', 'pension', 'retirement', 'roth',
                      'roth 401k', 'stock plan', 'tfsa', 'trust', 'paypal', 'savings', 'prepaid', 'business', 'commercial', 'construction', 'loan', 'cash management', 'mutual fund', 'rewards']
-        if [a['account_id'] for a in self.data['accounts'] if a['subtype'] in bonus_acc]:
+        if [a['account_id'] for a in self.acc if a['subtype'] in bonus_acc]:
             self.assertGreaterEqual(
-                diversity_profile(self.data, self.fb, self.par[14], self.par[5])[0], 0.17)
-        self.assertEqual(diversity_profile(self.data, self.fb, self.par[14], self.par[5])[0], 1)
+                diversity_profile(self.acc, self.fb, self.par)[0], 0.17)
+        self.assertEqual(diversity_profile(self.acc, self.fb, self.par)[0], 1)
 
 
 class TestHelperFunctions(unittest.TestCase):
@@ -365,7 +392,11 @@ class TestHelperFunctions(unittest.TestCase):
         self.fb['fetch'] = {}
 
         with open(json_file) as f:
-            self.data = str_to_datetime(json.load(f), self.fb)
+            data = str_to_datetime(json.load(f), self.fb)
+        self.acc = data['accounts']
+        txn = data['transactions']
+        txn = merge_dict(txn, self.acc, "account_id", ["type", "subtype"])
+        self.txn = sorted(txn, key=lambda d: d["date"])
 
         # import params
         score_range = configs['score_range']
@@ -374,7 +405,8 @@ class TestHelperFunctions(unittest.TestCase):
 
     def tearDown(self):
         self.fb = None
-        self.data = None
+        self.acc = None
+        self.txn = None
         self.par = None
 
     def test_dynamic_select(self):
@@ -384,9 +416,9 @@ class TestHelperFunctions(unittest.TestCase):
         - bad data should still return a dict with 'inexistent' id for the best account
         (Notice that 'credit' and 'checking' are used interchangeably here and are both equally valid input parameters)
         '''
-        a = dynamic_select(self.data, 'credit', self.fb)
-        b = dynamic_select([], 'credit', self.fb)
-        c = dynamic_select(None, 'credit', self.fb)
+        a = dynamic_select(self.acc, self.txn, 'credit', self.fb)
+        b = dynamic_select(self.acc, [], 'credit', self.fb)
+        c = dynamic_select(None, self.txn, 'credit', self.fb)
         fn = [a, b, c]
 
         for x in fn:
@@ -394,7 +426,7 @@ class TestHelperFunctions(unittest.TestCase):
                 self.assertIsInstance(x, dict)
 
         self.assertEqual(len(a.keys()), 2)
-        self.assertIs(dynamic_select([], 'checking', self.fb)
+        self.assertIs(dynamic_select([], self.txn, 'checking', self.fb)
                       ['id'], 'inexistent')
 
     def test_flows(self):
@@ -404,9 +436,9 @@ class TestHelperFunctions(unittest.TestCase):
         - bad input data should return a NoneType
         - bad input parameters should return an error in feedback['fetch']
         '''
-        a = flows(self.data, 6, self.fb)
-        b = flows([], 6, self.fb)
-        c = flows(None, 6, self.fb)
+        a = flows(self.acc, self.txn, 6, self.fb)
+        b = flows([], self.txn, 6, self.fb)
+        c = flows(self.acc, None, 6, self.fb)
 
         self.assertIsInstance(a, pd.DataFrame)
         self.assertEqual(len(a), 6)
@@ -421,15 +453,13 @@ class TestHelperFunctions(unittest.TestCase):
         - output should be of type float or int
         - bad input data should return an error
         '''
-        b = balance_now_checking_only(self.data, self.fb)
+        b = balance_now_checking_only(self.acc, self.fb)
         expected_b = sum([a['balances']['current']
-                         for a in self.data['accounts'] if a['subtype'] == 'checking'])
+                         for a in self.acc if a['subtype'] == 'checking'])
 
         self.assertEqual(b, expected_b)
         self.assertIsInstance(b, (float, int))
-
-        balance_now_checking_only([], self.fb)
-        self.assertIn('balance_now_checking_only', self.fb['fetch'].keys())
+        self.assertRaises(Exception, balance_now_checking_only, ([], self.fb))
 
 
 # -------------------------------------------------------------------------- #
@@ -458,39 +488,64 @@ class TestParametrizePlaid(unittest.TestCase):
         self.fb['fetch'] = {}
 
         with open(json_file) as f:
-            self.data = str_to_datetime(json.load(f), self.fb)
+            data = str_to_datetime(json.load(f), self.fb)
+        self.acc = data['accounts']
+        txn = data['transactions']
+        txn = merge_dict(txn, self.acc, "account_id", ["type", "subtype"])
+        self.txn = sorted(txn, key=lambda d: d["date"])
+        self.cred = [d for d in self.acc if d["type"].lower() == "credit"]
+        self.dep = [d for d in self.acc if d["type"].lower() == "depository"]
+        self.n_dep = [d for d in self.acc if d["type"].lower() != "depository"]
 
         # import params
         score_range = configs['score_range']
         params = configs['minimum_requirements']['plaid']['params']
         self.par = plaid_params(params, score_range)
 
-        self.args1 = {
-            'good': [self.data, self.fb],
-            'empty': [[], self.fb],
-            'none': [None, self.fb]
+        self.args = {
+            'good': 
+            [
+                [self.txn, self.cred, self.fb, self.par],
+                [self.txn, self.cred, self.fb, self.par],
+                [self.acc, self.txn, self.fb, self.par],
+                [self.acc, self.txn, self.fb, self.par],
+                [self.acc, self.txn, self.fb, self.par],
+                [self.acc, self.txn, self.fb, self.par],
+
+                [self.txn, self.fb, self.par],
+                [self.txn, self.fb, self.par],
+                [self.acc, self.txn, self.fb, self.par],
+                [self.acc, self.txn, self.fb, self.par],
+                [self.acc, self.txn, self.fb, self.par],
+
+                [self.dep, self.n_dep, self.fb, self.par],
+                [self.acc, self.txn, self.fb, self.par],
+
+                [self.acc, self.txn, self.fb, self.par],
+                [self.acc, self.fb, self.par]
+            ],
+            'empty': 
+            [
+                [[], [], self.fb, self.par],
+                [[], [], self.fb, self.par],
+                [[], None, self.fb, self.par],
+                [None, None, self.fb, self.par],
+                [None, [], self.fb, self.par],
+                [[], [], self.fb, self.par],
+
+                [None, self.fb, self.par],
+                [[], self.fb, self.par],
+                [[], [], self.fb, self.par],
+                [None, [], self.fb, self.par],
+                [[], None, self.fb, self.par],
+
+                [[], [], self.fb, self.par],
+                [[], None, self.fb, self.par],
+
+                [None, None, self.fb, self.par],
+                [[], self.fb, self.par]        
+            ]
         }
-
-        self.args2 = [
-            [self.par[1], self.par[2], self.par[11]],
-            [self.par[1], self.par[4], self.par[10]],
-            [self.par[1], self.par[21], self.par[11]],
-            [self.par[14], self.par[22]],
-            [self.par[14], self.par[1]],
-            [self.par[14], self.par[15]],
-
-            [self.par[2], self.par[18], self.par[13]], 
-            [self.par[2], self.par[19], self.par[13]],
-            [self.par[7], self.par[17], self.par[10]],
-            [self.par[14], self.par[16]],
-            [self.par[14], self.par[9], self.par[8], self.par[10]],
-
-            [self.par[14], self.par[6]],
-            [self.par[1], self.par[20], self.par[11]],
-
-            [self.par[2], self.par[1], self.par[13]], 
-            [self.par[14], self.par[5]]  
-        ]
 
         self.fn = {
             'fn_good': [
@@ -516,16 +571,12 @@ class TestParametrizePlaid(unittest.TestCase):
         }
 
     def tearDown(self):
-        self.fb = None
-        self.data = None
-        self.args1 = None
-        self.args2 = None
-        self.fn = None
-        self.par = None
+        for y in [self.acc, self.txn, self.fb, self.args, self.fn, self.par, self.dep, self.n_dep]:
+            y = None
 
     def test_output_good(self):
-        for (f, a) in zip(self.fn['fn_good'], self.args2):
-            z = f(*self.args1['good'], *a)
+        for (f, a) in zip(self.fn['fn_good'], self.args['good']):
+            z = f(*a)
             with self.subTest():
                 self.assertIsInstance(z, tuple)
                 self.assertLessEqual(z[0], 1)
@@ -533,20 +584,12 @@ class TestParametrizePlaid(unittest.TestCase):
                 self.assertIsInstance(z[1], dict)
 
     def test_output_empty(self):
-        for (f, a) in zip(self.fn['fn_good'], self.args2):
-            z = f(*self.args1['empty'], *a)
+        for (f, a) in zip(self.fn['fn_good'], self.args['empty']):
+            z = f(*a)
             with self.subTest():
                 self.assertIsInstance(z, tuple)
                 self.assertEqual(z[0], 0)
                 self.assertIsInstance(z[0], (float, int))
-                self.assertIsInstance(z[1], dict)
-
-    def test_output_none(self):
-        for (f, a) in zip(self.fn['fn_good'], self.args2):
-            z = f(*self.args1['none'], *a)
-            with self.subTest():
-                self.assertIsInstance(z, tuple)
-                self.assertIsNotNone(z[0])
                 self.assertIsInstance(z[1], dict)
 
 


### PR DESCRIPTION
[#49]
Various code refactoring:
- Covalent: **params** object was a `list` and is now a `dict`
- Unit tests for Plaid and Covalent invoke model params using dict keys instead of indices
- Updated Docstring for Plaid and Covalent to match the params passed to every function
- Activate automated unit tests upon pushing to Git